### PR TITLE
Implement ScrollToTop

### DIFF
--- a/react-app/src/App.js
+++ b/react-app/src/App.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import ProductListingForm from './components/ProductListingForm';
 import ProductImageForm from './components/ProductImageForm';
@@ -38,7 +38,7 @@ function App() {
   }
 
   return (
-    <BrowserRouter>
+    <>
       <NavBar />
       <Switch>
         <Route path="/" exact={true}>
@@ -84,7 +84,7 @@ function App() {
           <PageNotFound />
         </Route>
       </Switch>
-    </BrowserRouter>
+    </>
   );
 }
 

--- a/react-app/src/components/ScrollToTop/ScrollToTop.js
+++ b/react-app/src/components/ScrollToTop/ScrollToTop.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * A component that scrolls the window up on every navigation
+ * https://v5.reactrouter.com/web/guides/scroll-restoration
+ */
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/react-app/src/components/ScrollToTop/index.js
+++ b/react-app/src/components/ScrollToTop/index.js
@@ -1,0 +1,3 @@
+import ScrollToTop from './ScrollToTop';
+
+export default ScrollToTop;

--- a/react-app/src/index.js
+++ b/react-app/src/index.js
@@ -5,6 +5,8 @@ import './index.css';
 import App from './App';
 import configureStore from './store';
 import { ModalProvider } from './context/Modal';
+import { BrowserRouter } from 'react-router-dom';
+import ScrollToTop from './components/ScrollToTop';
 
 const store = configureStore();
 
@@ -12,7 +14,10 @@ ReactDOM.render(
   <React.StrictMode>
     <Provider store={store}>
       <ModalProvider>
-        <App />
+        <BrowserRouter>
+          <ScrollToTop />
+          <App />
+        </BrowserRouter>
       </ModalProvider>
     </Provider>
   </React.StrictMode>,


### PR DESCRIPTION
Built a component `<ScrollToTop />` which uses an effect to scroll the window to the top on every navigation:
https://v5.reactrouter.com/web/guides/scroll-restoration

In order to implement it, I moved the `<BrowserRouter />` interface from `App.js` into `index.js`. There, the new component sits above `<App />` in the component hierarchy:

```
 <React.StrictMode>
    <Provider store={store}>
      <ModalProvider>
        <BrowserRouter>
          <ScrollToTop />
          <App />
        </BrowserRouter>
      </ModalProvider>
    </Provider>
  </React.StrictMode>,
```